### PR TITLE
fix: remove acpi_driver owner field for kernel >= 6.10

### DIFF
--- a/driver/samsung-galaxybook.c
+++ b/driver/samsung-galaxybook.c
@@ -24,6 +24,7 @@
 #include <linux/workqueue.h>
 #include <linux/input.h>
 #include <linux/input/sparse-keymap.h>
+#include <linux/version.h>
 
 #define SAMSUNG_GALAXYBOOK_CLASS  "samsung-galaxybook"
 #define SAMSUNG_GALAXYBOOK_NAME   "Samsung Galaxybook Extras"
@@ -1073,7 +1074,7 @@ static void galaxybook_performance_mode_hotkey_work(struct work_struct *work)
 {
 	struct samsung_galaxybook *galaxybook = container_of(work,
 			struct samsung_galaxybook, performance_mode_hotkey_work);
-	
+
 	platform_profile_set(&galaxybook->profile_handler,
 			performance_mode_hotkey_next_profile[galaxybook->current_profile]);
 
@@ -1646,7 +1647,10 @@ static struct acpi_driver galaxybook_acpi_driver = {
 		.remove = galaxybook_acpi_remove,
 		.notify = galaxybook_acpi_notify,
 		},
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
 	.owner = THIS_MODULE,
+#endif
 };
 
 static int __init samsung_galaxybook_init(void)


### PR DESCRIPTION
Fixes #19

The ACPI `.owner` field was removed with 6.10 in https://github.com/torvalds/linux/commit/cc85f9c05bba23eb525497b42ac5b74801ccbd87. This PR adds in a guard to prevent setting the owner field on kernel versions after 6.10. 

I have tested building this with `6.6.44`, `6.9.12`, `6.10.1`, and `6.10.3`. Functionality tested with only `6.10.1`. 