### PR TITLE
Some fixes on @rapgenic driver integration

### DIFF
--- a/61-keyboard-samsung-galaxybook.hwdb
+++ b/61-keyboard-samsung-galaxybook.hwdb
@@ -2,6 +2,8 @@
 # Samsung Galaxy Book series notebooks
 ###########################################################
 
+# xxxQDB: Galaxy Book 360 series
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svn[sS][aA][mM][sS][uU][nN][gG]*:pn[0-9][0-9][0-9]QDB:*
 # xxxXED: Galaxy Book2 series
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svn[sS][aA][mM][sS][uU][nN][gG]*:pn[0-9][0-9][0-9]XED:*
 # xxxQED: Galaxy Book2 360 series

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ sudo udevadm trigger
 
 Currently, these keyboard mapping rules should apply to all Galaxy Book2 and Book3 series notebooks by matching on an "svn" starting with "Samsung" (case insensitve) plus a "pn" string of three digits followed by any one of the following suffixes:
 
+- 'QDB' (Galaxy Book 360 series)
 - `XED` (Galaxy Book2 series)
 - `QED` (Galaxy Book2 360 series)
 - `XFG` (Galaxy Book3 series)

--- a/samsung-galaxybook.c
+++ b/samsung-galaxybook.c
@@ -3,7 +3,7 @@
  * Samsung Galaxybook Extras driver
  *
  * Copyright (c) 2024 Joshua Grisham <josh@joshuagrisham.com>
- * Copyright (c) 2024 Giulio Girardi <giulio@rapgenic.com>
+ * Copyright (c) 2024 Giulio Girardi <giulio.girardi@protechgroup.it>
  *
  * Implementation inspired by existing x86 platform drivers.
  * Thank you to the authors!
@@ -62,7 +62,7 @@ static void warn_param_override(const char *param_name)
 			"https://github.com/joshuagrisham/samsung-galaxybook-extras/issues\n",
 			param_name);
 }
-int galaxybook_param_set(const char *val, const struct kernel_param *kp) {
+static int galaxybook_param_set(const char *val, const struct kernel_param *kp) {
 	if (strcmp(kp->name, "kbd_backlight") == 0)
 		kbd_backlight_was_set = true;
 	if (strcmp(kp->name, "performance_mode") == 0)
@@ -254,11 +254,15 @@ struct sawb {
 #define KBD_BACKLIGHT_MAX_BRIGHTNESS  3
 
 #define ACPI_NOTIFY_BATTERY_STATE_CHANGED    0x61
+#define ACPI_NOTIFY_TABLE_OFF                0x6d
+#define ACPI_NOTIFY_TABLE_ON                 0x6c
 #define ACPI_NOTIFY_HOTKEY_PERFORMANCE_MODE  0x70
 
 static const struct key_entry galaxybook_acpi_keymap[] = {
 	{KE_KEY, ACPI_NOTIFY_BATTERY_STATE_CHANGED, { KEY_BATTERY } },
 	{KE_KEY, ACPI_NOTIFY_HOTKEY_PERFORMANCE_MODE, { KEY_PROG3 } },
+	{KE_KEY, ACPI_NOTIFY_TABLE_OFF, { KEY_PROG1 } },
+	{KE_KEY, ACPI_NOTIFY_TABLE_ON, { KEY_PROG2 } },
 	{KE_END, 0},
 };
 
@@ -316,7 +320,7 @@ static int galaxybook_acpi_method(struct samsung_galaxybook *galaxybook, acpi_st
 					purpose_str,
 					method);
 			status = -EIO;
-		} else if (out_obj->buffer.pointer[5] == 0xff) {
+		} else if (out_obj->buffer.pointer[4] == 0xff) {
 			pr_err("failed %s with ACPI method %s; failure code 0xff reported from device\n",
 					purpose_str,
 					method);
@@ -995,7 +999,7 @@ static ssize_t fan_speed_rpm_show(struct device *dev, struct device_attribute *a
 }
 static DEVICE_ATTR_RO(fan_speed_rpm);
 
-void galaxybook_fan_speed_exit(struct samsung_galaxybook *galaxybook)
+static void galaxybook_fan_speed_exit(struct samsung_galaxybook *galaxybook)
 {
 	sysfs_remove_file(&galaxybook->fan.dev.kobj, &dev_attr_fan_speed_rpm.attr);
 }


### PR DESCRIPTION
Hi @joshuagrisham!
As promised here is a PR of what I found while reviewing your driver.

There aren't many things to say, it works really well and it is almost on par with the windows driver!! (In some things even better)

I really found only one error, you were checking the sixth byte and not the fifth for the return value (RFLG) of the ACPI call.

Other things I did were 
* Adding my Galaxy Book model to the keymap HWDB
* Adding a ACPI battery hook to expose the maximum charge threshold in the "right place", which is `/sys/class/power_supply/BAT1/charge_control_end_threshold`. This will allow it to pop up as a setting in the gnome settings app when https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/2176 gets merged.
* Adding some `static` keywords to keep GCC quiet

I will be daily driving this driver for a few days, and report to you anything that will come up

P.s. I hope you don't mind, I'd like to add myself as a MODULE_AUTHOR.. It'd be a personal satisfaction to figure as one of the Linux kernel module authors :smile: 