### PR TITLE
Try to remove quirks and make each feature test itself before being enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,9 @@ The following features might be possible to implement but require  additional de
 
 ### Supported devices
 
-The devices supported by this platform driver should be any device where `sudo dmidecode --type 3` reports `Manufacturer: SAMSUNG ELECTRONICS CO., LTD.` and `Type: Notebook`, PLUS that the ACPI device `SCAI` is present with ACPI Device IDs matching the list given in the driver (`SAM0427`, `SAM0428`, and `SAM0429` at the time of this writing). This covers most of the currently available "Samsung Galaxy Book" series notebooks, but could include others as well.
+The devices supported by this platform driver should be any device where `sudo dmidecode --type 3` reports `Manufacturer: SAMSUNG ELECTRONICS CO., LTD.` and `Type: Notebook`, PLUS that the ACPI device `SCAI` is present with ACPI Device IDs matching the list given in the driver (`SAM0427`, `SAM0428`, `SAM0429` and `SAM0430` at the time of this writing). This covers most of the currently available "Samsung Galaxy Book" series notebooks, but could include others as well.
 
-Note that for the devices with the ACPI Device ID `SAM0427`, there will currently not be support for:
-- Performance mode
-- Fan speed
-- Hotkey support
-
-If you have a device with `SAM0427` and wish to help provide support to overcome the above limitations, please feel free to create an issue!
+The intention is that each feature within the platform driver attempts to test if it is supported or not in some way before the feature is enabled. Some devices have slightly different hardware and/or behave in a slightly different manner; if you have a device where the driver is disabling a certain feature which you believe should be supported, please create an issue!
 
 I have also seen that Windows uses the same driver for `SAM0426` (used by devices like the Notebook 9 Pro 15" and/or similar), so my suspicion is that large parts of this driver probably also work for these devices. If you have one of these devices, and want to test this driver with it, please create an issue for help and to share your findings.
 
@@ -54,13 +49,12 @@ The platform driver supports the following module parameters:
 - `kbd_backlight`: Enable Keyboard Backlight control (default on) (bool)
 - `battery_threshold`: Enable battery charge threshold control (default on) (bool)
 - `performance_mode`: Enable Performance Mode control (default on) (bool)
+- `allow_recording`: Enable control to allow or block access to camera and microphone (default on) (bool)
 - `fan_speed`: Enable fan speed (default on) (bool)
 - `i8042_filter`: Enable capturing keyboard hotkey events (default on) (bool)
-- `acpi_hotkeys`: Enable ACPI hotkey events (default on) (bool)
-- `wmi_hotkeys`: Enable WMI hotkey events (default on) (bool)
 - `debug`: Enable debug messages (default off) (bool)
 
-In general the intention of these parameters is to allow for enabling or disabling of various features provided by the driver, especially in cases where a particular feature does not appear to work with your device. The availability of the various "settings" flags (`usb_charge`, `start_on_lid_open`, etc) will always be enabled and cannot be disabled at this time.
+In general, the intention of these parameters is to allow for the enabling or disabling of various features provided by the driver, especially in cases where a particular feature appears to cause problems with your device. The availability of the various "settings" plattform attributes (`usb_charge`, `start_on_lid_open`, etc) will always be enabled if they appear to be supported, and cannot be disabled at this time.
 
 > **Note:** Please raise an issue if you find that you need to disable a certain feature in order to avoid a problem that it causes with your device!
 


### PR DESCRIPTION
After merging #30 then we have had several new issues reported, but they were mostly "valid" issues that were just not really noticed before. This is mostly because merging in @rapgenic 's driver logic helped to tighten up a lot of error checking, which now are actually being noticed by people! (instead of failing silently...)

I have been trying to kind of spot-fix each thing as they pop up, and we definitely have had some good improvements (IMO) such as changing to dynamically load performance modes and fans that were previously a bit "hard-coded" in how they were working.

But due to all of this, plus having even more issues reported where other features are not supported on some devices, I have been thinking more and more about the "pattern" for this driver especially as compared to other existing platform drivers, and specifically the idea that most of them cover quite a broad range of hardware variations with an attempt to "detect" what features are supported.

So based on that, I have spent some time trying to really think through how this could work, and even sketched out some flows etc, and tried to now update the driver to follow a similar ideology: for each feature, see if it appears to work, then enable it; otherwise, disable it. And hopefully by doing this, we don't even need any concept of "quirks" in this driver anymore; it will be more like a PnP platform driver for these devices' various possible features.

This PR is my first take on revamping a bit of the flow and adding some additional checks to achieve this. Fortunately, I found that the skeleton that already existed in the driver was pretty close to supporting this... just needed a few extra things added or moved around a bit!

Before this PR, the approach was instead: try to force usage of the feature as it is implemented; if it fails to init, just unload the entire driver, and tell the user to create an issue so that we could make some quirks or exception for their device. I think this old approach feels like it will not scale super well plus is a very "unfriendly" approach that goes against the PnP mindset.

My hope is that several of you who have reported issues and helped with testing before might be willing and able to test this branch and give some feedback in this PR if it seems to be working for you! https://github.com/joshuagrisham/samsung-galaxybook-extras/tree/no-quirks-test-before-enable

Anyone is of course willing and welcome to test and provide feedback on if it is working or not. Specifically I am also hoping for:

- @PremiumUsername can test and see how this works especially with the i8042 filter (I tried to clean it up a bit more and make it work like most other existing platform drivers in the kernel), and if not, please enable the debug param of the module and post the full dmesg if you can!
- @axcosta can test with your device if everything seems like it is still working?
- @enkiros can test if the kbd_backlight gets disabled with this automatically and it seems like all is working ok?
- @seaasses can test  if the problem you had in https://github.com/joshuagrisham/samsung-galaxybook-extras/issues/32 is still ok / does not happen with this branch from this PR
- and definitely if @rapgenic can check and see if you spot any other problems on your device and/or in general with these changes?