### PR TITLE
Add DKMS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ In general the intention of these parameters is to allow for enabling or disabli
 
 ### Building and installing
 
+#### Compiling and installing manually
+
 Compile the module out-of-tree but against the currently loaded kernel's modules:
 
 ```sh
@@ -97,6 +99,34 @@ Uninstall the module:
 
 ```sh
 sudo rm /lib/modules/`uname -r`/updates/samsung-galaxybook.ko*
+```
+
+#### Compiling and installing automatically with dkms
+
+This module can be installed with dkms and provides autoinstallation for every new kernel.
+
+Add module to dkms tree:
+
+```sh
+sudo dkms add /path/to/module/directory/samsung-galaxybook-extras
+```
+
+Build module:
+
+```sh
+sudo dkms build samsung-galaxybook/extras
+```
+
+Install module:
+
+```sh
+sudo dkms install samsung-galaxybook/extras
+```
+
+Uninstall module:
+
+```sh
+sudo dkms uninstall samsung-galaxybook/extras
 ```
 
 #### How to avoid 'signature and/or required key missing'

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="samsung-galaxybook"
+PACKAGE_VERSION="extras"
+BUILT_MODULE_NAME[0]="$PACKAGE_NAME"
+DEST_MODULE_LOCATION[0]="/updates/dkms/$PACKAGE_NAME/"
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
+CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+AUTOINSTALL="yes"


### PR DESCRIPTION
Hi, @joshuagrisham.
Just a configuration file and instructions added to README to use the module with [DKMS](https://github.com/dell/dkms).

Currently, I using this module with DKMS because my distro updates the kernel frequently and it's a bit sad to recompile it every time the system updates, so the DKMS is just a way to autoinstall the module every time the system install a new kernel.