### PR TITLE
Change struct platform_driver's member remove_new to remove for kernel 6.13

### DIFF
--- a/samsung-galaxybook.c
+++ b/samsung-galaxybook.c
@@ -1527,7 +1527,7 @@ static void galaxybook_allow_recording_hotkey_work(struct work_struct *work)
 }
 
 static bool galaxybook_i8042_filter(unsigned char data, unsigned char str,
-				    				struct serio *port)
+				    				struct serio *port, void *context)
 {
 	static bool extended;
 
@@ -1543,7 +1543,7 @@ static bool galaxybook_i8042_filter(unsigned char data, unsigned char str,
 		switch (data) {
 		case GB_KEY_KBD_BACKLIGHT_KEYDOWN:
 			pr_debug_prefixed("hotkey: kbd_backlight keydown\n");
-			break;
+			break;:
 		case GB_KEY_KBD_BACKLIGHT_KEYUP:
 			pr_debug_prefixed("hotkey: kbd_backlight keyup\n");
 			if (kbd_backlight)
@@ -1836,7 +1836,7 @@ static int galaxybook_probe(struct platform_device *pdev)
 			INIT_WORK(&galaxybook->allow_recording_hotkey_work,
 					galaxybook_allow_recording_hotkey_work);
 
-		err = i8042_install_filter(galaxybook_i8042_filter);
+		err = i8042_install_filter(galaxybook_i8042_filter, NULL);
 		if (err) {
 			pr_err("failed to install i8402 key filter\n");
 			cancel_work_sync(&galaxybook->kbd_backlight_hotkey_work);

--- a/samsung-galaxybook.c
+++ b/samsung-galaxybook.c
@@ -1933,7 +1933,7 @@ static struct platform_driver galaxybook_platform_driver = {
 		.acpi_match_table = galaxybook_device_ids,
 	},
 	.probe = galaxybook_probe,
-	.remove_new = galaxybook_remove,
+	.remove = galaxybook_remove,
 };
 
 static int __init samsung_galaxybook_init(void)

--- a/samsung-galaxybook.c
+++ b/samsung-galaxybook.c
@@ -1933,7 +1933,11 @@ static struct platform_driver galaxybook_platform_driver = {
 		.acpi_match_table = galaxybook_device_ids,
 	},
 	.probe = galaxybook_probe,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 	.remove = galaxybook_remove,
+#else
+	.remove_new = galaxybook_remove,
+#endif
 };
 
 static int __init samsung_galaxybook_init(void)


### PR DESCRIPTION
As of kernel 6.13 the struct platform_driver no longer has the member remove_new, instead it is now remove. It has been fixed by correcting a line of code. Here is an error on compiling for 6.13 if you don't correct it:

```shell
linking '/nix/store/x027xq6lr2q44jfdhxcg7w9knqgq7bmf-user-units/graphical-session.target.wants/yubikey-touch-detector.service' to '"/nix/store/.links/1xqxcwhq7qckdjg9d7m3gswkmpw8zljay572ifysp7ywi7srvv2y"'
error: builder for '/nix/store/vmx64gj15ms2w3h19dvvgr0z6mprrdib-samsung-galaxybook-extras-0.9-6.13.0.drv' failed with exit code 2;
       last 24 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/qpa8lwx7vgydlp6pi5fx6mqxmygs0gib-source
       > source root is source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > build flags: -j16 SHELL=/nix/store/gwgqdl0242ymlikq9s9s62gkp5cvyal3-bash-5.2p37/bin/bash KERNELRELEASE=6.13.0 KERNEL_SRC=/nix/store/yams2a5wc4qg2i815affb5yh1pbwgf3k-linux-6.13-dev/lib/modules/6.13.0/build INSTALL_MOD_PATH=\$\(out\)/lib/modules/6.13.0/kernel
       > make -C /nix/store/yams2a5wc4qg2i815affb5yh1pbwgf3k-linux-6.13-dev/lib/modules/6.13.0/build M=/build/source modules
       > make[1]: Entering directory '/nix/store/yams2a5wc4qg2i815affb5yh1pbwgf3k-linux-6.13-dev/lib/modules/6.13.0/build'
       > make[2]: Entering directory '/build/source'
       >   CC [M]  samsung-galaxybook.o
       > samsung-galaxybook.c:1936:10: error: 'struct platform_driver' has no member named 'remove_new'; did you mean 'remove'?
       >  1936 |         .remove_new = galaxybook_remove,
       >       |          ^~~~~~~~~~
       >       |          remove
       > make[4]: *** [/nix/store/yams2a5wc4qg2i815affb5yh1pbwgf3k-linux-6.13-dev/lib/modules/6.13.0/source/scripts/Makefile.build:194: samsung-galaxybook.o] Error 1
       > make[3]: *** [/nix/store/yams2a5wc4qg2i815affb5yh1pbwgf3k-linux-6.13-dev/lib/modules/6.13.0/source/Makefile:1989: .] Error 2
       > make[2]: *** [/nix/store/yams2a5wc4qg2i815affb5yh1pbwgf3k-linux-6.13-dev/lib/modules/6.13.0/source/Makefile:251: __sub-make] Error 2
       > make[2]: Leaving directory '/build/source'
       > make[1]: *** [/nix/store/yams2a5wc4qg2i815affb5yh1pbwgf3k-linux-6.13-dev/lib/modules/6.13.0/source/Makefile:251: __sub-make] Error 2
       > make[1]: Leaving directory '/nix/store/yams2a5wc4qg2i815affb5yh1pbwgf3k-linux-6.13-dev/lib/modules/6.13.0/build'
       > make: *** [Makefile:5: all] Error 2
       For full logs, run 'nix log /nix/store/vmx64gj15ms2w3h19dvvgr0z6mprrdib-samsung-galaxybook-extras-0.9-6.13.0.drv'.
```