### PR TITLE
fix: switch platform_driver's remove_new field to remove for kernels >= 6.13

### DIFF
--- a/samsung-galaxybook.c
+++ b/samsung-galaxybook.c
@@ -1933,7 +1933,12 @@ static struct platform_driver galaxybook_platform_driver = {
 		.acpi_match_table = galaxybook_device_ids,
 	},
 	.probe = galaxybook_probe,
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+  .remove = galaxybook_remove,
+#else
 	.remove_new = galaxybook_remove,
+#endif
 };
 
 static int __init samsung_galaxybook_init(void)


### PR DESCRIPTION
Supersedes #54, adding a preprocessor macro to only make the change for kernels >= 6.13.0. Build tested on 6.12.8 and 6.13.1-zen.